### PR TITLE
feat: Allow trusted apps to perform cookie login.

### DIFF
--- a/openedx/core/djangoapps/auth_exchange/tests/test_views.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_views.py
@@ -160,11 +160,15 @@ class TestLoginWithAccessTokenView(TestCase):
         if expected_cookie_name:
             assert expected_cookie_name in response.cookies
 
-    def _create_dot_access_token(self, grant_type='Client credentials'):
+    def _create_dot_access_token(self, grant_type='Client credentials', skip_authorization=False):
         """
         Create dot based access token
         """
-        dot_application = dot_factories.ApplicationFactory(user=self.user, authorization_grant_type=grant_type)
+        dot_application = dot_factories.ApplicationFactory(
+            user=self.user,
+            authorization_grant_type=grant_type,
+            skip_authorization=skip_authorization,
+        )
         return dot_factories.AccessTokenFactory(user=self.user, application=dot_application)
 
     def test_invalid_token(self):
@@ -180,3 +184,7 @@ class TestLoginWithAccessTokenView(TestCase):
     def test_dot_client_credentials_unsupported(self):
         access_token = self._create_dot_access_token()
         self._verify_response(access_token, expected_status_code=401)
+
+    def test_dot_client_credentials_supported_if_authorization_skipped(self):
+        access_token = self._create_dot_access_token(skip_authorization=True)
+        self._verify_response(access_token, expected_status_code=204, expected_cookie_name='sessionid')


### PR DESCRIPTION
## Description

This pull request allows Oauth applications with the 'skip_authorization' flag to use the cookie login view. This view is used to grant a session cookie as though the user had logged in directly with their username and password. This functionality already works with 'Resource Owner Password Based' grants.

Previous discussion as to why this view was only permitted for Resource Owner Password Based grants pointed toward the need to support third party applications but not allow them to leapfrog privileges.

However, for applications which have the 'skip authorization' flag set, no restrictions on scope are enforced, as the application is permitted to grant itself all scopes without requiring the user's explicit authorization. This kind of power already nearly mirrors cookie login, however some endpoints on the platform are unable to support non-cookie functionality, such as the loading of units and XBlocks.

## Supporting information

[Slack Thread](https://openedx.slack.com/archives/C0F0NA2F5/p1553173366050600?thread_ts=1550459747.003300&cid=C0F0NA2F5) on the current limitation.

## Testing instructions

The easiest way to test is to run the software tests via the devstack using:

```
pytest openedx/core/djangoapps/auth_exchange
```

But to test it more practically, you would need to:

1. Create an Oauth Application in the Django admin that uses a grant type of Authorization
2. Use a client OAuth app with the new application credentials to log in
3. Have the authenticated client post to `/oauth2/login/` on the LMS
4. Verify that the cookie was set and a successful status code (204) was returned.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

This change has some implication for security. While it is of the author's opinion that any application which has the 'skip_authorization' flag set should be considered a trusted application anyway, since it can grant all scopes (and thus has the full power of the API available to the user) any application with this flag may as well be able to log in via cookie.

However that does not necessarily mean that deployments are set up with this assumption. It is conceivable that there could be misconfigured applications that would have the ability to login that otherwise wouldn't, and which would have additional powers unexpected. It seems unlikely that these powers would be especially material, since full privileged API access is already so vast.